### PR TITLE
MULE-15562: Fix Mule-4-Status-Windows pipeline

### DIFF
--- a/mule-extensions-xml-archetype/pom.xml
+++ b/mule-extensions-xml-archetype/pom.xml
@@ -89,6 +89,7 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <regex>false</regex>
                             <basedir>${project.build.directory}/test-classes/projects</basedir>
                             <includes>
                                 <include>**/goal.txt</include>


### PR DESCRIPTION
- Regex property must be set to false otherwise the settings file path
passed by Maven's property `mule.extension.archetype.testSettings` will
be treated as a regex, therefore on Windows Systems the backslash will
be treated as a special char and will be deleted leaving a corrupted
file path.

- By default, this property is set to true on replacer's plugin config.
When so, the replacer plugin uses under the hood the
java.util.regex.Matcher#replaceAll method in its TokenReplacer class
where the actual replacement is carried on.

- According to Java docs "Note that backslashes (\) and dollar signs ($)
in the replacement string may cause the results to be different than if
it were being treated as a literal replacement string. [...] and
backslashes are used to escape literal characters in the replacement
string."