### PR TITLE
Update README.md

### DIFF
--- a/mule-extensions-archetype/src/main/resources/archetype-resources/README.md
+++ b/mule-extensions-archetype/src/main/resources/archetype-resources/README.md
@@ -18,4 +18,5 @@ Add this dependency to your application pom.xml
 <groupId>${groupId}</groupId>
 <artifactId>${artifactId}</artifactId>
 <version>${version}</version>
+<classifier>mule-plugin</classifier>
 ```


### PR DESCRIPTION
`<classifier>mule-plugin</classifier>` was missing from generated Readme, but it's in the docs.