### PR TITLE
MULE-16475: Fix mule-extensions-archetype tests in Windows

### DIFF
--- a/mule-extensions-archetype-it/src/test/java/org/mule/extension/archetype/it/ExtensionArchetypeGenerationTestCase.java
+++ b/mule-extensions-archetype-it/src/test/java/org/mule/extension/archetype/it/ExtensionArchetypeGenerationTestCase.java
@@ -152,7 +152,7 @@ public class ExtensionArchetypeGenerationTestCase {
   }
 
   private static Properties getPluginProperties() {
-    Properties props = System.getProperties();
+    Properties props = new Properties();
 
     // Archetype plugin properties
     props.put(ARCHETYPE_GID_PROP, EXTENSIONS_ARCHETYPE_GID);


### PR DESCRIPTION
- Disabling the loading of all system properties for executing Maven's
 goals due to the extensive length of the final string command which
 passes the allowed length for Windows cmd shell