### PR TITLE
Remove mandatory defaulted 'module-' namespace prefix.

### DIFF
--- a/mule-extensions-xml-archetype/src/main/resources/archetype-resources/src/main/resources/__packageInPathFormat__/module-__extensionName__.xml
+++ b/mule-extensions-xml-archetype/src/main/resources/archetype-resources/src/main/resources/__packageInPathFormat__/module-__extensionName__.xml
@@ -1,7 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-#set( $hyphenated_module_name = "module-${extensionName.toLowerCase().replace(' ', '-')}" )
+#set( $hyphenated_module_name = "${extensionName.toLowerCase().replace(' ', '-')}" )
 <?xml version="1.0" encoding="UTF-8"?>
 <module name="${extensionName} Smart Connector"
         prefix="${hyphenated_module_name}"

--- a/mule-extensions-xml-archetype/src/main/resources/archetype-resources/src/test/munit/assertion-munit-test.xml
+++ b/mule-extensions-xml-archetype/src/main/resources/archetype-resources/src/test/munit/assertion-munit-test.xml
@@ -1,7 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-#set( $hyphenated_module_name = "module-${extensionName.toLowerCase().replace(' ', '-')}" )
+#set( $hyphenated_module_name = "${extensionName.toLowerCase().replace(' ', '-')}" )
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:${hyphenated_module_name}="http://www.mulesoft.org/schema/mule/${hyphenated_module_name}"

--- a/mule-extensions-xml-archetype/src/test/resources/projects/basic-with-spaces/reference/src/main/resources/org/mule/extension/it/basic/with/spaces/module-Basic With Spaces.xml
+++ b/mule-extensions-xml-archetype/src/test/resources/projects/basic-with-spaces/reference/src/main/resources/org/mule/extension/it/basic/with/spaces/module-Basic With Spaces.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module name="Basic With Spaces Smart Connector"
-        prefix="module-basic-with-spaces"
+        prefix="basic-with-spaces"
         doc:description="This module relies in runtime provided components"
 
         xmlns="http://www.mulesoft.org/schema/mule/module"
         xmlns:mule="http://www.mulesoft.org/schema/mule/core"
         xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
-        xmlns:tns="http://www.mulesoft.org/schema/mule/module-basic-with-spaces"
+        xmlns:tns="http://www.mulesoft.org/schema/mule/basic-with-spaces"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
            http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-           http://www.mulesoft.org/schema/mule/module-basic-with-spaces http://www.mulesoft.org/schema/mule/module-basic-with-spaces/current/mule-module-basic-with-spaces.xsd">
+           http://www.mulesoft.org/schema/mule/basic-with-spaces http://www.mulesoft.org/schema/mule/basic-with-spaces/current/mule-basic-with-spaces.xsd">
 
     <operation name="set-payload-hardcoded" doc:description="Sets the payload to the String value 'Wubba Lubba Dub Dub'">
         <body>

--- a/mule-extensions-xml-archetype/src/test/resources/projects/basic-with-spaces/reference/src/test/munit/assertion-munit-test.xml
+++ b/mule-extensions-xml-archetype/src/test/resources/projects/basic-with-spaces/reference/src/test/munit/assertion-munit-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns:module-basic-with-spaces="http://www.mulesoft.org/schema/mule/module-basic-with-spaces"
+      xmlns:basic-with-spaces="http://www.mulesoft.org/schema/mule/basic-with-spaces"
 
       xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
       xmlns:munitext="http://www.mulesoft.org/schema/mule/munit-tools"
@@ -8,7 +8,7 @@
       xsi:schemaLocation="
         http://www.mulesoft.org/schema/mule/core      http://www.mulesoft.org/schema/mule/core/current/mule.xsd
         http://www.mulesoft.org/schema/mule/munit     http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
-        http://www.mulesoft.org/schema/mule/module-basic-with-spaces http://www.mulesoft.org/schema/mule/module-basic-with-spaces/current/mule-module-basic-with-spaces.xsd
+        http://www.mulesoft.org/schema/mule/basic-with-spaces http://www.mulesoft.org/schema/mule/basic-with-spaces/current/mule-basic-with-spaces.xsd
         http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd">
 
     <munit:config name="assertion-test.xml"/>
@@ -32,10 +32,10 @@
     </munit:test>
 
     <flow name="set-payload-hardcoded-flow">
-        <module-basic-with-spaces:set-payload-hardcoded/>
+        <basic-with-spaces:set-payload-hardcoded/>
     </flow>
 
     <flow name="set-payload-hardcoded-two-times-flow">
-        <module-basic-with-spaces:set-payload-hardcoded-two-times/>
+        <basic-with-spaces:set-payload-hardcoded-two-times/>
     </flow>
 </mule>

--- a/mule-extensions-xml-archetype/src/test/resources/projects/basic/reference/src/main/resources/org/mule/extension/it/basic/module-Basic.xml
+++ b/mule-extensions-xml-archetype/src/test/resources/projects/basic/reference/src/main/resources/org/mule/extension/it/basic/module-Basic.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module name="Basic Smart Connector"
-        prefix="module-basic"
+        prefix="basic"
         doc:description="This module relies in runtime provided components"
 
         xmlns="http://www.mulesoft.org/schema/mule/module"
         xmlns:mule="http://www.mulesoft.org/schema/mule/core"
         xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
-        xmlns:tns="http://www.mulesoft.org/schema/mule/module-basic"
+        xmlns:tns="http://www.mulesoft.org/schema/mule/basic"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="
            http://www.mulesoft.org/schema/mule/module http://www.mulesoft.org/schema/mule/module/current/mule-module.xsd
            http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-           http://www.mulesoft.org/schema/mule/module-basic http://www.mulesoft.org/schema/mule/module-basic/current/mule-module-basic.xsd">
+           http://www.mulesoft.org/schema/mule/basic http://www.mulesoft.org/schema/mule/basic/current/mule-basic.xsd">
 
     <operation name="set-payload-hardcoded" doc:description="Sets the payload to the String value 'Wubba Lubba Dub Dub'">
         <body>

--- a/mule-extensions-xml-archetype/src/test/resources/projects/basic/reference/src/test/munit/assertion-munit-test.xml
+++ b/mule-extensions-xml-archetype/src/test/resources/projects/basic/reference/src/test/munit/assertion-munit-test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns:module-basic="http://www.mulesoft.org/schema/mule/module-basic"
+      xmlns:basic="http://www.mulesoft.org/schema/mule/basic"
 
       xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
       xmlns:munitext="http://www.mulesoft.org/schema/mule/munit-tools"
@@ -8,7 +8,7 @@
       xsi:schemaLocation="
         http://www.mulesoft.org/schema/mule/core      http://www.mulesoft.org/schema/mule/core/current/mule.xsd
         http://www.mulesoft.org/schema/mule/munit     http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
-        http://www.mulesoft.org/schema/mule/module-basic http://www.mulesoft.org/schema/mule/module-basic/current/mule-module-basic.xsd
+        http://www.mulesoft.org/schema/mule/basic http://www.mulesoft.org/schema/mule/basic/current/mule-basic.xsd
         http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd">
 
     <munit:config name="assertion-test.xml"/>
@@ -32,10 +32,10 @@
     </munit:test>
 
     <flow name="set-payload-hardcoded-flow">
-        <module-basic:set-payload-hardcoded/>
+        <basic:set-payload-hardcoded/>
     </flow>
 
     <flow name="set-payload-hardcoded-two-times-flow">
-        <module-basic:set-payload-hardcoded-two-times/>
+        <basic:set-payload-hardcoded-two-times/>
     </flow>
 </mule>


### PR DESCRIPTION
Does not seem necessary to hardcode the 'module-' prefix for module namespaces. 

For example  'module-http:request'. The 'module-' prefix always gets manually removed in all my use-cases as typically I want the module operation to read 'http:request'.