### PR TITLE
W-16993079: Using mule-runtime-bom 4.8.1 release version to avoid hav…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,8 @@
     <parent>
         <groupId>org.mule</groupId>
         <artifactId>mule-plugin-mgmt-parent-pom</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <!-- Using mule-runtime-bom 4.8.1 release version to avoid having issues with SNAPSHOTs being deleted as it is not part of the Runtime Monthly Cycle release -->
+        <version>4.8.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -130,7 +131,8 @@
     <properties>
         <jdk.version>1.8</jdk.version>
 
-        <muleBomVersion>4.8.1-SNAPSHOT</muleBomVersion>
+        <!-- Using mule-runtime-bom 4.8.1 release version to avoid having issues with SNAPSHOTs being deleted as it is not part of the Runtime Monthly Cycle release -->
+        <muleBomVersion>4.8.1</muleBomVersion>
 
         <mule.extension.archetype.testSettings>${java.io.tmpdir}/effective-settings.xml</mule.extension.archetype.testSettings>
 


### PR DESCRIPTION
…ing issues with SNAPSHOTs being deleted as it is not part of the Runtime Monthly Cycle release